### PR TITLE
Sorting Functionality

### DIFF
--- a/VirtuTrade/Core/Home/Views/HomeView.swift
+++ b/VirtuTrade/Core/Home/Views/HomeView.swift
@@ -123,13 +123,46 @@ extension HomeView {
     
     private var columnTitles: some View {
         HStack {
-            Text("Coin")
-                Spacer()
-            if showPortfolio {
-                Text("Holdings")
+            HStack(spacing: 4) {
+                Text("Coin")
+                Image(systemName: "chevron.down")
+                    .opacity((vm.sortOption == .rank || vm.sortOption == .rankReversed) ? 1.0 : 0.0)
+                    .rotationEffect(Angle(degrees: vm.sortOption == .rank ? 0 : 180))
             }
-            Text("Price")
-                .frame(width: UIScreen.main.bounds.width / 3.5, alignment: .trailing)
+            .onTapGesture {
+                withAnimation(.default) {
+                    vm.sortOption = vm.sortOption == .rank ? .rankReversed : .rank
+                }
+            }
+            
+            Spacer()
+            
+            if showPortfolio {
+                HStack(spacing: 4) {
+                    Text("Holdings")
+                    Image(systemName: "chevron.down")
+                        .opacity((vm.sortOption == .holdings || vm.sortOption == .holdingsReversed) ? 1.0 : 0.0)
+                        .rotationEffect(Angle(degrees: vm.sortOption == .holdings ? 0 : 180))
+                }
+                .onTapGesture {
+                    withAnimation(.default) {
+                        vm.sortOption = vm.sortOption == .holdings ? .holdingsReversed : .holdings
+                    }
+                }
+            }
+            
+            HStack(spacing: 4) {
+                Text("Price")
+                Image(systemName: "chevron.down")
+                    .opacity((vm.sortOption == .price || vm.sortOption == .priceReversed) ? 1.0 : 0.0)
+                    .rotationEffect(Angle(degrees: vm.sortOption == .price ? 0 : 180))
+            }
+            .frame(width: UIScreen.main.bounds.width / 3.5, alignment: .trailing)
+            .onTapGesture {
+                withAnimation(.default) {
+                    vm.sortOption = vm.sortOption == .price ? .priceReversed : .price
+                }
+            }
         }
         .font(.subheadline)
         .fontWeight(.medium)


### PR DESCRIPTION
#### Summary
This pull request adds comprehensive sorting functionality for coins in VirtuTrade, allowing users to sort by rank, holdings, and price, with both ascending and descending options. Animated UI updates enhance the sorting experience.

#### Key Updates
- **Sorting Options in HomeViewModel**:
  - Added `sortOption` property to manage sorting state, with the following options:
    - **Rank**: Sort by coin rank in ascending or descending order.
    - **Holdings**: Sort by user's holdings in ascending or descending order.
    - **Price**: Sort by coin price in ascending or descending order.
  - Implemented functions for filtering and sorting:
    - `filterAndSortCoins()`: Filters and sorts the coin list based on search text and selected sort option.
    - `sortCoins()`: Handles sorting by rank, holdings, or price.
    - `sortPortfolioCoinsIfNeeded()`: Specifically sorts portfolio coins by holdings when required.

- **UI Enhancements in HomeView**:
  - Updated column titles to display sorting indicators, showing the current sort direction with icons.
  - Enabled sorting by tapping column headers, with smooth animations for sorting transitions.

#### Testing
- Verified each sorting option (rank, holdings, price) for accurate functionality and responsiveness.
- Ensured animations are smooth and visually consistent across different sorting actions.